### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -82,6 +82,8 @@ jobs:
 
   build:
     name: Build Binaries
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [lint, test]
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/ZenProjects/parsedmarc-go/security/code-scanning/33](https://github.com/ZenProjects/parsedmarc-go/security/code-scanning/33)

To remediate, we should explicitly set the job-level permission block for the "build" job in .github/workflows/go-build.yml. The minimal permissions required are `contents: read` — this allows the checkout of code and read-only access necessary for building and uploading artifacts. The block should be added directly beneath the job's metadata (e.g., after `name` and before `runs-on`). No additional dependencies are required to implement this fix, and it will not alter the build's functional behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
